### PR TITLE
Add Do not render the unit if it is not whitelisted

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -3,17 +3,20 @@ function setUnit(numericValue){
   var hoursToDays = 7.5;
 
   chrome.storage.local.get(["selectHRFor"], function(result) {
+    var whiteList = ["Days", "Hours"]
     var unit = result.selectHRFor;
     if(unit == numericValue.children[0].innerText) { return; }
 
-    var timeUnitHtml = `<span class="suffix" style="font-size:0.4em; white-space: pre; display:inline-block;">${unit}</span>`;
+    if(whiteList.includes(unit)){
+      var timeUnitHtml = `<span class="suffix" style="font-size:0.4em; white-space: pre; display:inline-block;">${unit}</span>`;
 
-    if(unit == 'Hours') {
-      numericValue.innerHTML = `${parseFloat(numericValue.innerText.replace('Days')) * hoursToDays}${timeUnitHtml}`;
-    } else if(unit == 'Days') {
-      numericValue.innerHTML = `${parseFloat(numericValue.innerText.replace('Hours')) / hoursToDays}${timeUnitHtml}`;
-    } else {
-      // Do nothing as unit not yet set
+      if(unit == 'Hours') {
+        numericValue.innerHTML = `${parseFloat(numericValue.innerText.replace('Days')) * hoursToDays}${timeUnitHtml}`;
+      } else if(unit == 'Days') {
+        numericValue.innerHTML = `${parseFloat(numericValue.innerText.replace('Hours')) / hoursToDays}${timeUnitHtml}`;
+      } else {
+        // Do nothing as unit not yet set
+      }
     }
   });
 }


### PR DESCRIPTION
**Why**
This PR helps to avoid the risk of the malicious HTML markup inclusion.

**What**
Only allow to render the `unit` if it came from whitelist.


